### PR TITLE
fix(SuiteLogger) fix error "unable to iterate object" for missing attributes

### DIFF
--- a/examples/listener.py
+++ b/examples/listener.py
@@ -104,4 +104,4 @@ class _DictObj(object):
         self._attrs = attributes
 
     def __getattr__(self, attr):
-        return self._attrs.get(attr, None)
+        return self._attrs.get(attr, [])


### PR DESCRIPTION
defaulting the getter of _DictObj to None produces errors within robotframeworks xmllogger if an attribute (tags most of the times) is empty within an element.
Returning an empty dict satisfies for-loops iterating over an missing attribute.
